### PR TITLE
Move `codemirror` to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "codemirror": "5.x"
   },
   "devDependencies": {
-    "browserify": "^16.5.0"
+    "browserify": "^16.5.0",
+    "codemirror": "^5.56.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/alincode/codemirror-solidity#readme",
   "license": "MIT",
-  "dependencies": {
-    "codemirror": "^5.56.0"
+  "peerDependencies": {
+    "codemirror": "5.x"
   },
   "devDependencies": {
     "browserify": "^16.5.0"


### PR DESCRIPTION
Avoid multiple copies of `codemirror` in a dependency tree.

https://nodejs.org/en/blog/npm/peer-dependencies/

Also added to `devDependencies` for the demo.