### PR TITLE
Exclude demo files from the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "codemirror-solidity",
   "version": "0.2.5",
   "description": "codemirror solidity mode",
+  "files": ["index.js"],
   "main": "index.js",
   "scripts": {
     "build": "browserify browser.js -o solidity.js",


### PR DESCRIPTION
The package includes unnecessary files from the demo:

![image](https://user-images.githubusercontent.com/639336/186070875-f03c296f-9785-455f-a68f-217ea396ec6d.png)

Exclude them by only including `index.js`. https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files